### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,31 +69,23 @@ BlockInstance Actor::getBlockFromViewVector(FaceID& face, bool includeLiquid, bo
 
 ### For Windows
 
-1. Download `LiteLoader.zip` from [Releases](https://github.com/LiteLDev/LiteLoader/releases)
-   or [Actions](https://github.com/LiteLDev/LiteLoader/actions), unzip it to BDS directory
-2. Run `SymDB2.exe` to generate symbol files(`bedrock_server.symdb2`) and BDS with export
-   symbols `bedrock_server_mod.exe`(plugins in future may require this version of bds), before you run `SymDB2.exe` you
-   need to check if the `bedrock_server.pdb` exists
+1. Download the latest <code>LiteLoader-<i>version</i>.zip</code> from [Releases](https://github.com/LiteLDev/LiteLoader/releases) or [Actions](https://github.com/LiteLDev/LiteLoader/actions), unzip everything to the directory of `bedrock_server.exe`. 
+2. Run `SymDB2.exe` to generate the symbol file(`bedrock_server.symdb2`) and BDS with exported symbols(`bedrock_server_mod.exe`, plugins in future may require this version of BDS). Before you run `SymDB2.exe`, you need to check if `bedrock_server.pdb` exists. 
+3. When the console says `Press any key to continue . . . `, press any key to close the window. Then open `bedrock_server_mod.exe` and enjoy it. 
 
 ### For Linux
-
+Enter the following lines in your terminal: 
 ```
 docker pull shrbox/liteloaderbds
 docker create --name liteloader -p 19132:19132/udp -i -t shrbox/liteloaderbds
 ```
+Start server: `docker container start liteloader`  
+Force stop server(not recommended): `docker container stop liteloader`  
+Enter console: `docker attach liteloader`  
+Exit console: Press `Ctrl + P + Q`. If you press `Ctrl + C`, the server process will exit.  
+If you want to manage server files, use `docker volume --help` for more details.  
 
-Start server: `docker container start liteloader`
-
-Stop server(unrecommended): `docker container stop liteloader`
-
-Enter console: `docker attach liteloader`
-
-Exit console: press `Ctrl + P + Q`. If you press `Ctrl + C`, the server process will exit. If you want to manage server
-file, use `docker volume --help` for more details
-
-Everything done! Next, you can install **LiteLoader** plugins!
-
-<br/>
+Everything's done! Next, you can install **LiteLoader** plugins!  
 
 ## 📥 Auto update
 

--- a/README_zh-cn.md
+++ b/README_zh-cn.md
@@ -64,27 +64,23 @@ BlockInstance Actor::getBlockFromViewVector(FaceID& face, bool includeLiquid, bo
 
 ### 对于 Windows 用户
 
-1. 从 [Releases](https://github.com/LiteLDev/LiteLoader/releases)
-   或 [Actions](https://github.com/LiteLDev/LiteLoader/actions) 下载 `LiteLoader.zip`，并将它解压到BDS目录
-2. 运行 `SymDB2.exe` 来生成符号文件(`bedrock_server.symdb2`)和有导出符号的BDS `bedrock_server_mod.exe`(未来的插件可能会需要这个版本的BDS)
-   。在你运行 `SymDB2.exe` 之前，你需要检查 `bedrock_server.pdb` 是否存在
+1. 从 [Releases](https://github.com/LiteLDev/LiteLoader/releases) 或 [Actions](https://github.com/LiteLDev/LiteLoader/actions) 下载最新的 <code>LiteLoader-<i>版本</i>.zip</code>，将压缩文件内的所有内容解压到 `bedrock_server.exe` 所在的目录。
+2. 运行 `SymDB2.exe` 来生成符号文件（`bedrock_server.symdb2`）和有导出符号的BDS（`bedrock_server_mod.exe`，未来的插件可能会需要这个版本的BDS）。在你运行 `SymDB2.exe` 之前，你需要检查 `bedrock_server.pdb` 是否存在。
+3. 当控制台输出 `请按任意键继续. . . ` 时，按任意键关闭窗口。然后打开 `bedrock_server_mod.exe`，即可使用。
 
 ### 对于 Linux 用户
-
+在终端中输入：
 ```
 docker pull shrbox/liteloaderbds
 docker create --name liteloader -p 19132:19132/udp -i -t shrbox/liteloaderbds
 ```
+启动服务器：`docker container start liteloader`  
+强制停止服务器（不推荐）：`docker container stop liteloader`  
+进入控制台：`docker attach liteloader`  
+退出控制台：按下 `Ctrl + P + Q`。如果按下 `Ctrl + C`，服务器进程将会终止。  
+如想管理服务端文件，使用命令 `docker volume --help` 了解详情。  
 
-开服: `docker container start liteloader`
-
-关服(不推荐): `docker container stop liteloader`
-
-进入控制台: `docker attach liteloader`
-
-退出控制台: 按下 `Ctrl + P + Q`，如果你按下 `Ctrl + C`，服务器进程将会退出 如果你想管理服务端文件，使用命令 `docker volume --help` 了解详情
-
-大功告成！ 接下来，你可以安装你想要的 **LiteLoader** 插件
+大功告成！接下来，你可以安装你想要的 **LiteLoader** 插件。  
 
 ## 📥 自动更新
 


### PR DESCRIPTION
修正了中文版 README 中“安装”一部分。修正后的内容来源于[Minecraft基岩版开发Wiki中收录的相关内容](https://wiki.bedev.cn/LiteLoader)。至于那边的来源……起初是从这边搬过来的，还有一部分是热心用户贡献的，另一些是我试着开了个 Windows 服务器后加的。昨天我刚刚修正完，现在在这边也同步一份。  
顺便修正了英文版 README 的对应部分。  
由于我不是服主，也不是主攻这方面的，所以修正完了可能还会出现错误，如果发现了请改正。  
