### PR TITLE
Projectile problem fixes.

### DIFF
--- a/LiteLoader/Header/EventAPI.h
+++ b/LiteLoader/Header/EventAPI.h
@@ -563,6 +563,11 @@ public:
     std::string mType;
 };
 
+class ProjectileCreatedEvent : public EventTemplate<ProjectileCreatedEvent> {
+public:
+    Actor* mShooter;
+    Actor* mProjectile;
+};
 
 class ArmorStandChangeEvent : public EventTemplate<ArmorStandChangeEvent> {
 public:


### PR DESCRIPTION
> Currently, the creation of tridents cannot be canceled correctly, if canceled, the tridents will disappear directly (fixed)
 - Fix bug in `ProjectileSpawnEvent`
> Added projectile creation complete event.
 - Add `ProjectileCreatedEvent`.

This PR has been tested with no issues.