### PR TITLE
Fix typo 'convertToColsole'

### DIFF
--- a/LiteLoader/Header/MC/ColorFormat.hpp
+++ b/LiteLoader/Header/MC/ColorFormat.hpp
@@ -25,15 +25,20 @@ LIAPI std::string nearestColorCodeFromConsoleCode(std::string const& consoleCode
 LIAPI std::string& convertToMc(std::string& str);
 LIAPI std::string convertToMc(std::string&& str);
 
+[[deprecated("This is a typo. Use convertToConsole instead")]]
 LIAPI std::string& convertToColsole(std::string& str, bool keepColorCode = false);
+[[deprecated("This is a typo. Use convertToConsole instead")]]
 LIAPI std::string convertToColsole(std::string&& str, bool keepColorCode = false);
+ 
+LIAPI std::string& convertToConsole(std::string& str, bool keepColorCode = false);
+LIAPI std::string convertToConsole(std::string&& str, bool keepColorCode = false);
 
 LIAPI std::string& removeColorCode(std::string& str);
 LIAPI std::string removeColorCode(std::string&& str);
 
 [[deprecated("Use convertToMc instead")]]
 LIAPI std::string& transferConsoleColorToColorCode(std::string& str);
-[[deprecated("Use convertToColsole instead")]]
+[[deprecated("Use convertToConsole instead")]]
 LIAPI std::string& transferColorCodeToConsole(std::string& str, bool keepColorCode = false);
 
 #undef AFTER_EXTRA

--- a/LiteLoader/Kernel/MC/ColorFormatAPI.cpp
+++ b/LiteLoader/Kernel/MC/ColorFormatAPI.cpp
@@ -195,8 +195,14 @@ std::string nearestColorCodeFromConsoleCode(std::string const& code) {
     return "";
 }
 
+// For compatibility
 std::string convertToColsole(std::string&& str, bool keepColorCode) {
-    convertToColsole(str, keepColorCode);
+    convertToConsole(str, keepColorCode);
+    return std::move(str);
+}
+
+std::string convertToConsole(std::string&& str, bool keepColorCode) {
+    convertToConsole(str, keepColorCode);
     return std::move(str);
 }
 
@@ -214,7 +220,13 @@ std::string removeColorCode(std::string&& str) {
     return std::move(str);
 }
 
-std::string& convertToColsole(std::string& str, bool keepColorCode) {
+// For compatibility
+std::string& convertToColsole(std::string& str, bool keepColorCode)
+{
+    return convertToConsole(str, keepColorCode);
+}
+
+std::string& convertToConsole(std::string& str, bool keepColorCode) {
     size_t size = str.size();
     for (size_t pos = str.find("§"); pos < size - 2; pos = str.find("§", pos)) {
         std::string consoleCode = consoleCodeFromColorCode(str.substr(pos, 3));
@@ -257,7 +269,7 @@ std::string& transferConsoleColorToColorCode(std::string& str) {
 }
 
 std::string& transferColorCodeToConsole(std::string& str, bool keepColorCode) {
-    return convertToColsole(str, keepColorCode);
+    return convertToConsole(str, keepColorCode);
 }
 
 #ifdef DEBUG

--- a/LiteLoader/Kernel/NBT/PrettySnbtFormatAPI.cpp
+++ b/LiteLoader/Kernel/NBT/PrettySnbtFormatAPI.cpp
@@ -60,8 +60,8 @@ inline void PrettySnbtFormat::ValueFormat::toPlayerFormat() {
     ColorFormat::convertToMc(mSuffix);
 }
 inline void PrettySnbtFormat::ValueFormat::toConsoleFormat() {
-    ColorFormat::convertToColsole(mPrefix);
-    ColorFormat::convertToColsole(mSuffix);
+    ColorFormat::convertToConsole(mPrefix);
+    ColorFormat::convertToConsole(mSuffix);
 }
 PrettySnbtFormat::PrettySnbtFormat() {
 #define InitFormat(type) mValueFormats[type] = {DefaultPrefix<type>, DefaultSuffix<type>};
@@ -159,9 +159,9 @@ void PrettySnbtFormat::switchToPlayerFormat() {
 void PrettySnbtFormat::switchToConsoleFormat() {
     if (!mForPlayer)
         return;
-    ColorFormat::convertToColsole(mIndent);
-    ColorFormat::convertToColsole(mSeparator);
-    ColorFormat::convertToColsole(mColon);
+    ColorFormat::convertToConsole(mIndent);
+    ColorFormat::convertToConsole(mSeparator);
+    ColorFormat::convertToConsole(mColon);
     mKeyFormat.toConsoleFormat();
     for (auto& format : mValueFormats) {
         format.toConsoleFormat();

--- a/LiteLoader/Main/AddonsHelper.cpp
+++ b/LiteLoader/Main/AddonsHelper.cpp
@@ -240,7 +240,7 @@ void FindManifest(vector<string>& result, const string& path) {
 
 std::string Addon::getPrintName() const {
     if (LL::globalConfig.colorLog)
-        return ColorFormat::convertToColsole(std::string(name));
+        return ColorFormat::convertToConsole(std::string(name));
     else
         return ColorFormat::removeColorCode(std::string(name));
 }

--- a/LiteLoader/Main/ModifyInfomation.cpp
+++ b/LiteLoader/Main/ModifyInfomation.cpp
@@ -120,7 +120,7 @@ TClasslessInstanceHook(void*, "?send@CommandOutputSender@@UEAAXAEBVCommandOrigin
     string line;
     while (getline(iss, line)) {
         if (LL::globalConfig.colorLog)
-            log << ColorFormat::convertToColsole(line, false) << Logger::endl;
+            log << ColorFormat::convertToConsole(line, false) << Logger::endl;
         else
             log << ColorFormat::removeColorCode(line) << Logger::endl;
     }


### PR DESCRIPTION
## Description
'convertToColsole' -> 'convertToConsole'

## Type of changes
- [ ] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/LiteLDev/LiteLoaderBDS/discussions/546)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
