### PR TITLE
Fix global namespace pollution

### DIFF
--- a/LiteLoader/Header/third-party/Nlohmann/fifo_json.hpp
+++ b/LiteLoader/Header/third-party/Nlohmann/fifo_json.hpp
@@ -1,8 +1,7 @@
 #include "json.hpp"
 #include "fifo_map.hpp"
 #include <string>
-using namespace nlohmann;
 
 template<class Key, class T, class dummy_compare, class Allocator>
-using workaround_fifo_map = fifo_map<Key, T, fifo_map_compare<Key>, Allocator>;
-using fifo_json = basic_json<workaround_fifo_map>;
+using workaround_fifo_map = nlohmann::fifo_map<Key, T, nlohmann::fifo_map_compare<Key>, Allocator>;
+using fifo_json = nlohmann::basic_json<workaround_fifo_map>;


### PR DESCRIPTION
## Description
移除了fifo_json.hpp中对于nlohmann命名空间的全局使用

## Issues fixed by this PR
在fifo_json.hpp中全局使用了nlohmann命名空间，然后Tag.hpp包含了fifo_json.hpp。
经过一系列的头文件包含，导致一旦包含了MC下的大部分头文件，都会自动使用nlohmann命名空间。
由此引发的另一个问题就是在包含了MC下的某些头文件的情况下，再包含jsoncpp将会导致一系列的JSON::*重定义错误。

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/LiteLDev/LiteLoaderBDS/discussions/546)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
