### PR TITLE
Refactor checkRunningBDS()

### DIFF
--- a/LiteLoader/src/liteloader/LiteLoader.cpp
+++ b/LiteLoader/src/liteloader/LiteLoader.cpp
@@ -148,22 +148,28 @@ void checkRunningBDS() {
             if (path == currentPath) {
                 logger.error(tr("ll.main.checkRunningBDS.detected"));
                 logger.error(tr("ll.main.checkRunningBDS.tip"));
-                logger.error(tr("ll.main.checkRunningBDS.ask", pid));
-                char ch;
-                rewind(stdin);
-                ch = getchar();
-                rewind(stdin);
-                if (ch == 'y' || ch == 'Y') {
-                    // auto cmd = "taskkill /F /PID " + std::to_string(pid);
-                    // system(cmd.c_str());
-                    TerminateProcess(handle, 1);
+                while (true) {
+                    logger.error(tr("ll.main.checkRunningBDS.ask", pid));
+                    char input;
+                    rewind(stdin);
+                    input = getchar();
+                    rewind(stdin);
+                    if (input == 'n' || input == 'N') {
+                        break;
+                    }
+                    if (input == 'y' || input == 'Y') {
+                        TerminateProcess(handle, 1);
+                        break;
+                    }
+                    if (input == 'e' || input == 'E') {
+                        std::terminate();
+                        break;
+                    }
                 }
             }
-
             CloseHandle(handle);
         }
     }
-
     delete[] buffer;
 }
 

--- a/LiteLoader/src/liteloader/LiteLoader.cpp
+++ b/LiteLoader/src/liteloader/LiteLoader.cpp
@@ -150,7 +150,9 @@ void checkRunningBDS() {
                 logger.error(tr("ll.main.checkRunningBDS.tip"));
                 logger.error(tr("ll.main.checkRunningBDS.ask", pid));
                 char ch;
-                cin >> ch;
+                rewind(stdin);
+                ch = getchar();
+                rewind(stdin);
                 if (ch == 'y' || ch == 'Y') {
                     // auto cmd = "taskkill /F /PID " + std::to_string(pid);
                     // system(cmd.c_str());


### PR DESCRIPTION
## Description
Use getchar() instead of std::cin() in function checkRunningBDS()

## Issues fixed by this PR
Close #912 

## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://docs.litebds.com/#/zh_CN/Maintenance/README)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
