### PR TITLE
Fix generation fails when the project directory contains spaces

### DIFF
--- a/LiteLoader/CMakeLists.txt
+++ b/LiteLoader/CMakeLists.txt
@@ -72,7 +72,7 @@ target_include_directories(
 
 add_custom_command(
         TARGET LiteLoader PRE_BUILD
-        COMMAND cmd /c ${CMAKE_SOURCE_DIR}/scripts/PrepareLibraries.cmd ${CMAKE_SOURCE_DIR}
+        COMMAND ${CMAKE_SOURCE_DIR}/scripts/PrepareLibraries.cmd ${CMAKE_SOURCE_DIR}
 )
 
 # Copy the built DLL and PDB to the output directory


### PR DESCRIPTION
## Description
Remove "cmd /c" which may cause the problem of generation failure when the project directory contains spaces.

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://docs.litebds.com/#/zh_CN/Maintenance/README)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
