### PR TITLE
fix: fastlog PlayerAttackEvent::mAttackDamage; mod onHopperSearchItem onHopperPushOut onAttackEntity

### DIFF
--- a/LiteLoader/include/llapi/EventAPI.h
+++ b/LiteLoader/include/llapi/EventAPI.h
@@ -282,7 +282,7 @@ class PlayerAttackEvent : public EventTemplate<PlayerAttackEvent> {
 public:
     Player* mPlayer = nullptr;
     Actor* mTarget = nullptr;
-    float mAttackDamage = 0;
+    int mAttackDamage = false;
 };
 
 class PlayerAttackBlockEvent : public EventTemplate<PlayerAttackBlockEvent> {

--- a/LiteLoader/include/llapi/EventAPI.h
+++ b/LiteLoader/include/llapi/EventAPI.h
@@ -110,9 +110,7 @@ private:
     bool deleted = false;
 
 public:
-    explicit EventListener(int id)
-    : listenerId(id) {
-    }
+    explicit EventListener(int id) : listenerId(id) {}
 
     /**
      * @brief Stop listening to the event and remove the event listener.
@@ -171,7 +169,6 @@ public:
     bool callToPlugin(std::string pluginName) {
         return EventManager<EVENT>::callToPlugin(pluginName, *(EVENT*)this);
     }
-
 
     ////////////////////// For compatibility DO NOT UPDATE //////////////////////
 protected:
@@ -285,7 +282,7 @@ class PlayerAttackEvent : public EventTemplate<PlayerAttackEvent> {
 public:
     Player* mPlayer = nullptr;
     Actor* mTarget = nullptr;
-    int mAttackDamage = false;
+    float mAttackDamage = 0;
 };
 
 class PlayerAttackBlockEvent : public EventTemplate<PlayerAttackBlockEvent> {
@@ -332,13 +329,13 @@ class PlayerEatEvent : public EventTemplate<PlayerEatEvent> {
 public:
     Player* mPlayer;
     ItemStack* mFoodItem;
-}; 
+};
 
 class PlayerAteEvent : public EventTemplate<PlayerAteEvent> {
 public:
     Player* mPlayer;
     ItemStack* mFoodItem;
-}; 
+};
 
 class PlayerConsumeTotemEvent : public EventTemplate<PlayerConsumeTotemEvent> {
 public:
@@ -541,13 +538,15 @@ public:
 class HopperSearchItemEvent : public EventTemplate<HopperSearchItemEvent> {
 public:
     bool isMinecart = false;
-    BlockInstance mHopperBlock;
-    Vec3 mMinecartPos;
+    ItemStack* mItemStack;
+    Vec3 mPos;
     int mDimensionId = -1;
 };
 
 class HopperPushOutEvent : public EventTemplate<HopperPushOutEvent> {
 public:
+    bool isMinecart = false;
+    ItemStack* mItemStack;
     Vec3 mPos;
     int mDimensionId = -1;
 };
@@ -688,12 +687,10 @@ public:
 
 class MobSpawnEvent : public EventTemplate<MobSpawnEvent> {
 public:
-    [[deprecated("MobSpawnEvent is outdated, please use MobTrySpawnEvent instead")]]
-    string mTypeName;
+    [[deprecated("MobSpawnEvent is outdated, please use MobTrySpawnEvent instead")]] string mTypeName;
     Vec3 mPos;
     int mDimensionId = -1;
 };
-
 
 class MobTrySpawnEvent : public EventTemplate<MobTrySpawnEvent> {
 public:
@@ -714,19 +711,16 @@ public:
 /* region ## Other Events ## */
 ///////////////////////////// Other Events /////////////////////////////
 
-class PostInitEvent : public EventTemplate<PostInitEvent> {
-};
+class PostInitEvent : public EventTemplate<PostInitEvent> {};
 
 /**
  * @brief An event that fires as the server has started.
  *
  * @note This event cannot be suppressed.
  */
-class ServerStartedEvent : public EventTemplate<ServerStartedEvent> {
-};
+class ServerStartedEvent : public EventTemplate<ServerStartedEvent> {};
 
-class ServerStoppedEvent : public EventTemplate<ServerStoppedEvent> {
-};
+class ServerStoppedEvent : public EventTemplate<ServerStoppedEvent> {};
 
 class ConsoleCmdEvent : public EventTemplate<ConsoleCmdEvent> {
 public:

--- a/LiteLoader/src/llapi/EventAPI.cpp
+++ b/LiteLoader/src/llapi/EventAPI.cpp
@@ -499,14 +499,14 @@ TInstanceHook(float, "?calculateAttackDamage@Actor@@QEAAMAEAV1@@Z", Actor, Actor
             PlayerAttackEvent ev{};
             ev.mPlayer = currentAttackingPlayer.player;
             ev.mTarget = currentAttackingPlayer.target;
-            ev.mAttackDamage = damage;
+            ev.mAttackDamage = (int)damage;
             currentAttackingPlayer.player = nullptr;
             currentAttackingPlayer.target = nullptr;
             if (!ev.call()) {
                 currentAttackingPlayer.cancelled = true;
                 return 0;
             }
-            return ev.mAttackDamage;
+            return (float)ev.mAttackDamage;
         }
         IF_LISTENED_END(PlayerAttackEvent)
     }

--- a/ScriptEngine/src/api/DataAPI.cpp
+++ b/ScriptEngine/src/api/DataAPI.cpp
@@ -251,7 +251,13 @@ bool ConfJsonClass::reload() {
     if (!jsonTexts)
         return false;
 
-    jsonConf = fifo_json::parse(*jsonTexts, nullptr, true, true);
+    try {
+        jsonConf = fifo_json::parse(*jsonTexts, nullptr, true, true);
+    } catch (...){
+        logger.error("Fail in confJsonReload!");
+        PrintScriptStackTrace();
+    }
+
     return true;
 }
 

--- a/ScriptEngine/src/api/EventAPI.cpp
+++ b/ScriptEngine/src/api/EventAPI.cpp
@@ -400,7 +400,7 @@ void EnableEventListener(int eventId) {
             Event::PlayerAttackEvent::subscribe([](const PlayerAttackEvent& ev) {
                 IF_LISTENED(EVENT_TYPES::onAttackEntity) {
                     if (ev.mTarget) {
-                        CallEvent(EVENT_TYPES::onAttackEntity, PlayerClass::newPlayer(ev.mPlayer), EntityClass::newEntity(ev.mTarget));
+                        CallEvent(EVENT_TYPES::onAttackEntity, PlayerClass::newPlayer(ev.mPlayer), EntityClass::newEntity(ev.mTarget), Number::newNumber(ev.mAttackDamage));
                     }
                 }
                 IF_LISTENED_END(EVENT_TYPES::onAttackEntity);
@@ -984,12 +984,8 @@ void EnableEventListener(int eventId) {
         case EVENT_TYPES::onHopperSearchItem:
             Event::HopperSearchItemEvent::subscribe([](const HopperSearchItemEvent& ev) {
                 IF_LISTENED(EVENT_TYPES::onHopperSearchItem) {
-                    if (ev.isMinecart) {
-                        CallEvent(EVENT_TYPES::onHopperSearchItem, FloatPos::newPos(ev.mMinecartPos, ev.mDimensionId), Boolean::newBoolean(ev.isMinecart));
-                    } else {
-                        BlockInstance bl = ev.mHopperBlock;
-                        CallEvent(EVENT_TYPES::onHopperSearchItem, FloatPos::newPos(bl.getPosition().toVec3(), ev.mDimensionId), Boolean::newBoolean(ev.isMinecart));
-                    }
+                    CallEvent(EVENT_TYPES::onHopperSearchItem, FloatPos::newPos(ev.mPos, ev.mDimensionId),
+                              Boolean::newBoolean(ev.isMinecart), ItemClass::newItem(ev.mItemStack));
                 }
                 IF_LISTENED_END(EVENT_TYPES::onHopperSearchItem);
             });
@@ -998,7 +994,8 @@ void EnableEventListener(int eventId) {
         case EVENT_TYPES::onHopperPushOut:
             Event::HopperPushOutEvent::subscribe([](const HopperPushOutEvent& ev) {
                 IF_LISTENED(EVENT_TYPES::onHopperPushOut) {
-                    CallEvent(EVENT_TYPES::onHopperPushOut, FloatPos::newPos(ev.mPos, ev.mDimensionId));
+                    CallEvent(EVENT_TYPES::onHopperSearchItem, FloatPos::newPos(ev.mPos, ev.mDimensionId),
+                              Boolean::newBoolean(ev.isMinecart), ItemClass::newItem(ev.mItemStack));
                 }
                 IF_LISTENED_END(EVENT_TYPES::onHopperPushOut);
             });

--- a/ScriptEngine/src/api/ScriptAPI.cpp
+++ b/ScriptEngine/src/api/ScriptAPI.cpp
@@ -104,7 +104,6 @@ Local<Value> FastLog(const Arguments& args) {
         ostringstream sout;
         for (int i = 0; i < args.size(); ++i)
             PrintValue(sout, args[i]);
-        sout << endl;
 
         pool.enqueue([str{sout.str()}, pluginName{ENGINE_OWN_DATA()->pluginName}]() {
             Logger fastLogger(pluginName);


### PR DESCRIPTION
## Description

fix: 
fastlog error, wrong PlayerAttackEvent::mAttackDamage

feat: 
add item object to ` onHopperSearchItem `, ` onHopperPushOut ` event
add damage argument to llse ` onAttackEntity ` event

## Issues fixed

Close #1027 #1050 #990 