### PR TITLE
fix struct AvailableCommandsPacket

### DIFF
--- a/LiteLoader/include/llapi/mc/AvailableCommandsPacket.hpp
+++ b/LiteLoader/include/llapi/mc/AvailableCommandsPacket.hpp
@@ -45,43 +45,50 @@ public:
     struct OverloadData
     {
         std::vector<ParamData> datas;
+        bool chained;
     };
     struct CommandData
     {
-        std::string name;                    //0
-        std::string description;             //32
-        CommandFlag flag;                    //64
-        CommandPermissionLevel perm;         //66
-        std::vector<OverloadData> overloads; //72
-        signed int aliasIndex;               //96
-    };//104
+        std::string name;                    // 0
+        std::string description;             // 32
+        CommandFlag flag;                    // 64
+        CommandPermissionLevel perm;         // 66
+        std::vector<OverloadData> overloads; // 72
+        std::vector<int> chainedOffsets;     // 96
+        signed int aliasIndex;               // 120
+    };                                       // 128
     struct SoftEnumData
     {
         std::string name;
         std::vector<std::string> values;
-    };//56
-
+    };
+    struct ChainedSubcommandDataValue
+    {
+        unsigned int index;
+        unsigned int value;
+    };
     struct ChainedSubcommandData
     {
-
+        std::string name;
+        std::vector<ChainedSubcommandDataValue> valueIndices;
     };
 
-std::vector<std::string> mAllEnums;//48
-std::vector<std::string> mChainedSubcommandValues;// 72
-std::vector<std::string> mAllSuffix; // 96
-std::vector<EnumData> mEnumDatas;//120
-std::vector<ChainedSubcommandData> mChainedSubcommands; // 144
-std::vector<CommandData> mCommandDatas;// 168
-std::vector<SoftEnumData> mSoftEnums;// 192
-std::vector<ConstrainedValueData> mConstrainedValueDatas; //216
-inline void test()
-{
+    std::vector<std::string> mAllEnums;                       // 48
+    std::vector<std::string> mAllSuffix;                      // 48+24=72
+    std::vector<EnumData> mEnumDatas;                         // 48+24*2=96
+    std::vector<std::string> mChainedSubcommandValues;        // 48+24*3=120
+    std::vector<ChainedSubcommandData> mChainedSubcommands;   // 48+24*4=144
+    std::vector<CommandData> mCommandDatas;                   // 48+24*5=168
+    std::vector<SoftEnumData> mSoftEnums;                     // 48+24*6=192
+    std::vector<ConstrainedValueData> mConstrainedValueDatas; // 48+24*7=216
+
+inline void test() {
     static_assert(sizeof(AvailableCommandsPacket) == 240);
     static_assert(sizeof(EnumData) == 56);
-    static_assert(sizeof(CommandData) == 104);
+    static_assert(sizeof(CommandData) == 128);
     static_assert(offsetof(CommandData, perm) == 66);
     static_assert(offsetof(AvailableCommandsPacket, mAllEnums) == 48);
-    static_assert(offsetof(AvailableCommandsPacket, mAllSuffix) == 96);
+    static_assert(offsetof(AvailableCommandsPacket, mAllSuffix) == 72);
     static_assert(offsetof(AvailableCommandsPacket, mConstrainedValueDatas) == 216);
 }
 

--- a/LiteLoader/include/llapi/mc/ClientboundMapItemDataPacket.hpp
+++ b/LiteLoader/include/llapi/mc/ClientboundMapItemDataPacket.hpp
@@ -22,6 +22,7 @@ class ClientboundMapItemDataPacket : public Packet {
 
 #define AFTER_EXTRA
 // Add Member There
+    char val[0xC8]{};
 
 #undef AFTER_EXTRA
 #ifndef DISABLE_CONSTRUCTOR_PREVENTION_CLIENTBOUNDMAPITEMDATAPACKET


### PR DESCRIPTION
fix struct AvailableCommandsPacket & add size in ClientboundMapItemDataPacket

## Description

<!--
Please carefully read the [Contributing Note](https://docs.litebds.com/#/Maintenance/README) before making any pull requests.
And, **The base branch should be `LiteLDev:develop` not `LiteLDev:main`**
-->
- fix struct AvailableCommandsPacket
  - already tested by serialized to JSON and deserialized from JSON
- add size in ClientboundMapItemDataPacket

## Issues fixed

<!--
Put the links of issues that may be fixed by this PR here (if any).
Please use "Close #xxx" statement to link this PR to a existing issue.
-->
_None_

<!--
Well done! Let's take a self check before submitting the PR.

Checklist: 

[ ] My code follows the style guidelines of this project
[ ] My pull request is unique and no other pull requests have been opened for these changes
[ ] I have read the [Contributing Note](https://docs.litebds.com/#/zh_CN/Maintenance/README)
[ ] I am responsible for any copyright issues with my code if it occurs in the future.

-->
