### PR TITLE
fix: fix memory leak of SimulatedPlayer's bugfix

### DIFF
--- a/LiteLoader/include/llapi/mc/ChunkViewSource.hpp
+++ b/LiteLoader/include/llapi/mc/ChunkViewSource.hpp
@@ -20,6 +20,7 @@ class ChunkViewSource : public ChunkSource {
 
 #define AFTER_EXTRA
 // Add Member There
+#define ENABLE_VIRTUAL_FAKESYMBOL_CHUNKVIEWSOURCE
 public:
 char filler[0x188];
 


### PR DESCRIPTION
## Description

<!--
Please carefully read the [Contributing Note](https://docs.litebds.com/#/Maintenance/README) before making any pull requests.
And, **The base branch should be `LiteLDev:develop` not `LiteLDev:main`**
-->
https://github.com/LiteLDev/LiteLoaderBDS/blob/50eb2650568b631679154190fc834bb89b81800b/LiteLoader/src/liteloader/BuiltinBugFix.cpp#L452-L457
这里构造的shared_ptr使用的析构函数是默认的，会导致内存泄露。
表现为SimulatedPlayer退出后那块区域依然加载（/testfor @e 存在实体）

## Issues fixed

<!--
Put the links of issues that may be fixed by this PR here (if any).
Please use "Close #xxx" statement to link this PR to a existing issue.
-->
_None_

<!--
Well done! Let's take a self check before submitting the PR.

Checklist: 

[ ] My code follows the style guidelines of this project
[ ] My pull request is unique and no other pull requests have been opened for these changes
[ ] I have read the [Contributing Note](https://docs.litebds.com/#/zh_CN/Maintenance/README)
[ ] I am responsible for any copyright issues with my code if it occurs in the future.

-->
