### PR TITLE
Add missing packet

### DIFF
--- a/LiteLoader/include/llapi/mc/inc/enums.inc
+++ b/LiteLoader/include/llapi/mc/inc/enums.inc
@@ -634,6 +634,7 @@ enum class MinecraftPacketIds : int {
     CompressedBiomeDefinitionList     = 0x12D,
     TrimData                          = 0x12E,
     OpenSign                          = 0x12F,
+    AgentAnimation                    = 0x130,
 };
 
 enum class ItemStackNetResult : unsigned char {


### PR DESCRIPTION
I added a missing packet to the MinecraftPacketIds enum.

Checklist: 

[✅] My code follows the style guidelines of this project
[✅] My pull request is unique and no other pull requests have been opened for these changes
[✅] I have read the [Contributing Note](https://docs.litebds.com/#/zh_CN/Maintenance/README)
[✅] I am responsible for any copyright issues with my code if it occurs in the future.

-->
