### PR TITLE
fix: fix mod not loaded when dependencies is an empty array

### DIFF
--- a/src/ll/core/mod/ModRegistrar.cpp
+++ b/src/ll/core/mod/ModRegistrar.cpp
@@ -180,7 +180,7 @@ void ModRegistrar::loadAllMods() noexcept try {
     }
     for (auto& name : loadingQueueHash) {
         auto& manifest = manifests.at(name);
-        if (manifest.dependencies) {
+        if (manifest.dependencies && !manifest.dependencies->empty()) {
             bool denied = false;
             for (auto& dependency : *manifest.dependencies) {
                 if (!loadingQueueHash.contains(dependency.name)) {
@@ -191,8 +191,12 @@ void ModRegistrar::loadAllMods() noexcept try {
                 getLogger().error("{0} will not be loaded because the dependencies can't loaded"_tr(name));
                 continue;
             }
+            size_t nonSelfDependenciesCount = 0;
             for (auto& dependency : *manifest.dependencies) {
-                impl->deps.emplaceDependency(name, dependency.name);
+                if (impl->deps.emplaceDependency(name, dependency.name)) nonSelfDependenciesCount++;
+            }
+            if (nonSelfDependenciesCount == 0) {
+                impl->deps.emplace(name);
             }
         } else {
             impl->deps.emplace(name);

--- a/src/ll/core/mod/ModRegistrar.cpp
+++ b/src/ll/core/mod/ModRegistrar.cpp
@@ -191,12 +191,8 @@ void ModRegistrar::loadAllMods() noexcept try {
                 getLogger().error("{0} will not be loaded because the dependencies can't loaded"_tr(name));
                 continue;
             }
-            size_t nonSelfDependenciesCount = 0;
             for (auto& dependency : *manifest.dependencies) {
-                if (impl->deps.emplaceDependency(name, dependency.name)) nonSelfDependenciesCount++;
-            }
-            if (nonSelfDependenciesCount == 0) {
-                impl->deps.emplace(name);
+                impl->deps.emplaceDependency(name, dependency.name);
             }
         } else {
             impl->deps.emplace(name);


### PR DESCRIPTION
## What does this PR do?

fix mod not loaded when it depends on itself or dependencies is an empty array.

example manifests:
```jsonc
{
  "name": "thirst",
  "entry": "thirst.dll",
  "version": "1.0.0",
  "type": "native",
  "author": "killcerr",
  "dependencies": []
}
```
## Which issues does this PR resolve?



## Checklist before merging

Thank you for your contribution to the repository. 
Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] Your code follows the code style of this repository (see the wiki)
- [x] You have tested all functions
- [x] You have not used code without license
- [x] You have added statement for third-party code
